### PR TITLE
Normalize activity events to taskId (GH #19)

### DIFF
--- a/bin/mc.js
+++ b/bin/mc.js
@@ -32,6 +32,7 @@
 import { AutomergeStore } from '../lib/automerge-store.js';
 import * as agentTrace from '../lib/agent-trace.js';
 import { SyncRequestError, requestJson } from '../lib/sync-client.js';
+import { activityTaskId } from '../lib/activity-task-id.js';
 
 const API_BASE = process.env.MC_SYNC_SERVER || `http://localhost:${process.env.MC_HTTP_PORT || '8004'}`;
 const API_TOKEN = process.env.MC_API_TOKEN || null;
@@ -376,7 +377,8 @@ async function main() {
         console.log('Recent activity:\n');
         for (const a of activities) {
           const agentStr = a.agent ? `@${a.agent}` : '';
-          const taskStr = a.task_id || a.taskId ? `[${a.task_id || a.taskId}]` : '';
+          const tid = activityTaskId(a);
+          const taskStr = tid ? `[${tid}]` : '';
           console.log(`  ${formatTime(a.timestamp)} ${a.type} ${agentStr} ${taskStr}`);
         }
       }
@@ -522,7 +524,7 @@ async function main() {
         timeline = timeline.filter(e => e.agent === agent);
       }
       if (taskFilter) {
-        timeline = timeline.filter(e => (e.task_id || e.taskId) === taskFilter);
+        timeline = timeline.filter(e => activityTaskId(e) === taskFilter);
       }
       
       timeline = timeline.slice(0, limit);
@@ -547,7 +549,7 @@ async function main() {
           console.log(`│`);
           console.log(`│ ${icon} ${formatTime(entry.timestamp)} - ${entry.agent ? `@${entry.agent}` : 'System'}`);
           
-          const taskId = entry.task_id || entry.taskId;
+          const taskId = activityTaskId(entry);
           if (taskId) {
             const task = doc.tasks?.[taskId];
             if (task) {

--- a/lib/activity-task-id.js
+++ b/lib/activity-task-id.js
@@ -1,0 +1,8 @@
+/**
+ * Canonical task id on activity feed entries.
+ * New events use `taskId`; legacy documents may still have `task_id`.
+ */
+export function activityTaskId(entry) {
+  if (!entry || typeof entry !== 'object') return undefined
+  return entry.taskId ?? entry.task_id
+}

--- a/lib/automerge-store.js
+++ b/lib/automerge-store.js
@@ -9,6 +9,7 @@ import { NodeFSStorageAdapter } from './nodefs-storage-adapter.js'
 import { randomBytes } from 'crypto'
 import { dirname, join } from 'path'
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'fs'
+import { activityTaskId } from './activity-task-id.js'
 
 // Generate short ID
 function genId(prefix = '') {
@@ -136,7 +137,7 @@ export class AutomergeStore {
       doc.activity.push({
         id: genId('a'),
         type: 'comment_added',
-        task_id: taskId,
+        taskId,
         agent,
         comment_id: commentId,
         timestamp: new Date().toISOString()
@@ -193,7 +194,7 @@ export class AutomergeStore {
     
     // Apply filters
     if (options.task) {
-      activity = activity.filter(item => item.task_id === options.task)
+      activity = activity.filter(item => activityTaskId(item) === options.task)
     }
     
     if (options.agent) {
@@ -276,7 +277,7 @@ export class AutomergeStore {
     
     // Apply filters
     if (options.task) {
-      activity = activity.filter(item => item.task_id === options.task)
+      activity = activity.filter(item => activityTaskId(item) === options.task)
     }
     
     if (options.agent) {
@@ -299,9 +300,8 @@ export class AutomergeStore {
     await this.ensureReady()
     const doc = this.docHandle.doc()
     
-    // Get activity for this task (activity uses 'taskId' not 'task_id')
     const activity = (doc.activity || [])
-      .filter(a => a.task_id === taskId || a.taskId === taskId)
+      .filter(a => activityTaskId(a) === taskId)
       .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp))
     
     // Get explicit task history from Patchwork tracking
@@ -447,7 +447,7 @@ export class AutomergeStore {
       doc.activity.push({
         id: genId('a'),
         type: 'task_branched',
-        task_id: taskId,
+        taskId,
         branch_id: branchId,
         branch_name: branchName,
         agent,
@@ -548,7 +548,7 @@ export class AutomergeStore {
       doc.activity.push({
         id: genId('a'),
         type: 'task_merged',
-        task_id: parentId,
+        taskId: parentId,
         branch_id: branchId,
         agent,
         details: `Merged branch: ${branch.branch_name}`,
@@ -604,7 +604,7 @@ export class AutomergeStore {
       doc.activity.push({
         id: genId('a'),
         type: 'task_updated',
-        task_id: taskId,
+        taskId,
         agent,
         details: changes.map(c => `${c.field}: ${c.old} → ${c.new}`).join(', '),
         timestamp: new Date().toISOString()

--- a/scripts/smoke/cli-integration-smoke.js
+++ b/scripts/smoke/cli-integration-smoke.js
@@ -6,6 +6,7 @@
  */
 
 import { AutomergeStore } from '../../lib/automerge-store.js'
+import { activityTaskId } from '../../lib/activity-task-id.js'
 
 async function testCliIntegration() {
   console.log('🔧 Testing MC CLI Integration with Automerge Backend\n')
@@ -62,7 +63,7 @@ async function testCliIntegration() {
   const activity = await store.getActivity({ limit: 5 })
   activity.forEach((event, i) => {
     const timeAgo = Math.floor((Date.now() - new Date(event.timestamp)) / 1000)
-    console.log(`   ${timeAgo}s ago ${event.type} @${event.agent} [${event.task_id || 'general'}]`)
+    console.log(`   ${timeAgo}s ago ${event.type} @${event.agent} [${activityTaskId(event) || 'general'}]`)
   })
   console.log('')
   

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,14 @@
+# GH #19 — Normalize activity `taskId`
+
+- [x] Add `activityTaskId()` helper for legacy read path
+- [x] Write new activity events with `taskId` only in `automerge-store.js`
+- [x] Filter/query activity via helper in store, CLI, UI
+- [x] Tests + verify
+
+## Review
+
+- Added `lib/activity-task-id.js` with `activityTaskId()` (`taskId` first, then legacy `task_id`).
+- `AutomergeStore` now writes `taskId` on all task-scoped activity events; `getActivity`, `getTimeline`, and `getTaskHistory` filter via the helper.
+- UI (`MissionControlSync.jsx`), CLI (`mc.js`), and smoke script use the same helper for reads.
+- `recordCommit` / sync-server paths already used `taskId`; unchanged.
+- Comments and mentions still use `task_id` (out of scope for activity feed issue).

--- a/test/activity-task-id.test.js
+++ b/test/activity-task-id.test.js
@@ -50,7 +50,7 @@ describe('AutomergeStore activity task field', () => {
     const evt = (doc.activity || []).find(a => a.type === 'comment_added')
     assert.ok(evt, 'activity event exists')
     assert.strictEqual(evt.taskId, 'legacy-task')
-    assert.strictEqual(evt.task_id, undefined)
+    assert.ok(!('task_id' in evt), 'new events must not set task_id')
   })
 
   it('getActivity filters by task using legacy task_id on stored events', async () => {
@@ -68,5 +68,99 @@ describe('AutomergeStore activity task field', () => {
       filtered.some(e => e.id === 'old-event'),
       'legacy task_id entry should match filter'
     )
+  })
+
+  it('getTimeline filters by task using legacy task_id on stored events', async () => {
+    const filtered = await store.getTimeline({ task: 'legacy-task' })
+    assert.ok(
+      filtered.some(e => e.id === 'old-event'),
+      'getTimeline should match getActivity for legacy task_id rows'
+    )
+  })
+})
+
+describe('AutomergeStore activity writers (branch / merge / update)', () => {
+  let store
+
+  before(async () => {
+    store = new AutomergeStore({
+      storagePath: '/tmp/mc-activity-writers-test-' + Date.now(),
+      usePersistedUrl: false
+    })
+    await store.init()
+    await store.docHandle.change(doc => {
+      if (!doc.tasks) doc.tasks = {}
+      const ts = new Date().toISOString()
+      doc.tasks['parent-task'] = {
+        id: 'parent-task',
+        title: 'Parent',
+        description: '',
+        status: 'todo',
+        assignee: null,
+        type: 'task',
+        priority: 'p2',
+        created_at: ts,
+        updated_at: ts
+      }
+    })
+  })
+
+  after(async () => {
+    if (store) await store.close()
+  })
+
+  it('createBranch logs task_branched with taskId only', async () => {
+    const branchId = await store.createBranch('parent-task', 'exp-branch', 'alice')
+    assert.ok(branchId)
+    const doc = store.getDoc()
+    const evt = (doc.activity || []).find(
+      a => a.type === 'task_branched' && a.branch_id === branchId
+    )
+    assert.ok(evt, 'task_branched activity exists')
+    assert.strictEqual(evt.taskId, 'parent-task')
+    assert.ok(!('task_id' in evt))
+  })
+
+  it('mergeBranch logs task_merged with taskId only', async () => {
+    const doc = store.getDoc()
+    const branchId = Object.keys(doc.tasks).find(
+      id => doc.tasks[id].branch_of === 'parent-task' && !doc.tasks[id].merged
+    )
+    assert.ok(branchId, 'unmerged branch exists')
+    const result = await store.mergeBranch(branchId, 'bob')
+    assert.strictEqual(result.success, true)
+    const doc2 = store.getDoc()
+    const evt = (doc2.activity || []).find(
+      a => a.type === 'task_merged' && a.branch_id === branchId
+    )
+    assert.ok(evt, 'task_merged activity exists')
+    assert.strictEqual(evt.taskId, 'parent-task')
+    assert.ok(!('task_id' in evt))
+  })
+
+  it('updateTask logs task_updated with taskId only', async () => {
+    await store.docHandle.change(doc => {
+      const ts = new Date().toISOString()
+      doc.tasks['upd-task'] = {
+        id: 'upd-task',
+        title: 'To update',
+        description: '',
+        status: 'todo',
+        assignee: null,
+        type: 'task',
+        priority: 'p2',
+        created_at: ts,
+        updated_at: ts
+      }
+    })
+    await store.updateTask('upd-task', { status: 'in-progress' }, 'carol')
+    const doc = store.getDoc()
+    const evts = (doc.activity || []).filter(
+      a => a.type === 'task_updated' && activityTaskId(a) === 'upd-task'
+    )
+    const evt = evts[evts.length - 1]
+    assert.ok(evt, 'task_updated activity exists')
+    assert.strictEqual(evt.taskId, 'upd-task')
+    assert.ok(!('task_id' in evt))
   })
 })

--- a/test/activity-task-id.test.js
+++ b/test/activity-task-id.test.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert'
+import { activityTaskId } from '../lib/activity-task-id.js'
+import { AutomergeStore } from '../lib/automerge-store.js'
+
+describe('activityTaskId', () => {
+  it('prefers taskId when both are present', () => {
+    assert.strictEqual(activityTaskId({ taskId: 'a', task_id: 'b' }), 'a')
+  })
+
+  it('falls back to task_id for legacy documents', () => {
+    assert.strictEqual(activityTaskId({ task_id: 'legacy' }), 'legacy')
+  })
+
+  it('returns undefined for missing or invalid entries', () => {
+    assert.strictEqual(activityTaskId(null), undefined)
+    assert.strictEqual(activityTaskId(undefined), undefined)
+    assert.strictEqual(activityTaskId({}), undefined)
+  })
+})
+
+describe('AutomergeStore activity task field', () => {
+  let store
+
+  before(async () => {
+    store = new AutomergeStore({
+      storagePath: '/tmp/mc-activity-taskid-test-' + Date.now(),
+      usePersistedUrl: false
+    })
+    await store.init()
+    await store.docHandle.change(doc => {
+      if (!doc.tasks) doc.tasks = {}
+      doc.tasks['legacy-task'] = {
+        id: 'legacy-task',
+        title: 'Legacy',
+        status: 'todo',
+        created_at: new Date().toISOString()
+      }
+    })
+  })
+
+  after(async () => {
+    if (store) await store.close()
+  })
+
+  it('writes comment_added activity with taskId only', async () => {
+    await store.addComment('legacy-task', 'hello', 'agent')
+    const doc = store.getDoc()
+    const evt = (doc.activity || []).find(a => a.type === 'comment_added')
+    assert.ok(evt, 'activity event exists')
+    assert.strictEqual(evt.taskId, 'legacy-task')
+    assert.strictEqual(evt.task_id, undefined)
+  })
+
+  it('getActivity filters by task using legacy task_id on stored events', async () => {
+    await store.docHandle.change(doc => {
+      doc.activity.push({
+        id: 'old-event',
+        type: 'task_updated',
+        task_id: 'legacy-task',
+        agent: 'bot',
+        timestamp: new Date().toISOString()
+      })
+    })
+    const filtered = await store.getActivity({ task: 'legacy-task' })
+    assert.ok(
+      filtered.some(e => e.id === 'old-event'),
+      'legacy task_id entry should match filter'
+    )
+  })
+})

--- a/ui-prototype/src/MissionControlSync.jsx
+++ b/ui-prototype/src/MissionControlSync.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { requestJson, withBearerAuthHeaders } from '../../lib/sync-client.js'
+import { activityTaskId } from '../../lib/activity-task-id.js'
 
 // Global lastSeen state (single user, synced across all devices via Automerge)
 const API_TOKEN = import.meta.env.VITE_MC_API_TOKEN || null
@@ -198,8 +199,7 @@ export default function MissionControlSync() {
           comments={getTaskComments(selectedTask.id)}
           agents={agents}
           taskHistory={(doc.taskHistory || {})[selectedTask.id] || []}
-          // TODO: normalize activity events to use consistent `taskId` field at creation time
-          taskActivity={(doc.activity || []).filter(a => (a.task_id || a.taskId) === selectedTask.id)}
+          taskActivity={(doc.activity || []).filter(a => activityTaskId(a) === selectedTask.id)}
           onClose={() => setSelectedTask(null)}
           onUpdate={updateTask}
           onComment={addComment}
@@ -651,7 +651,7 @@ function ActivityView({ doc, onSelectTask }) {
         if (commitHashes.has(entry.commitHash)) continue
       }
       
-      const taskId = entry.task_id || entry.taskId
+      const taskId = activityTaskId(entry)
       const task = taskId ? (doc.tasks || {})[taskId] : null
       
       events.push({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implements [GH #19](https://github.com/depatchedmode/mission-control/issues/19): canonical `taskId` on **activity** feed entries, with a single legacy read path.

## Changes
- **`lib/activity-task-id.js`** — `activityTaskId(entry)` returns `entry.taskId ?? entry.task_id`.
- **`lib/automerge-store.js`** — All new task-scoped activity writes use `taskId` (`comment_added`, `task_branched`, `task_merged`, `task_updated`). `getActivity`, `getTimeline`, and `getTaskHistory` filter using `activityTaskId()`. (`commit_linked` already used `taskId`.)
- **UI** (`MissionControlSync.jsx`) — Task detail activity filter and global timeline use `activityTaskId`.
- **CLI** (`bin/mc.js`) — `mc activity` and `mc timeline` use `activityTaskId`.
- **Smoke** (`scripts/smoke/cli-integration-smoke.js`) — same for printed activity lines.
- **Tests** (`test/activity-task-id.test.js`) — helper behavior; new writes; legacy `task_id` filtered by `getActivity` and **`getTimeline`**; **`createBranch` / `mergeBranch` / `updateTask`** activity rows use `taskId` only (`!('task_id' in evt)`).

## Out of scope
Comments and mentions keep `task_id` (separate document shapes; issue targets activity feed only).

## Verification
- `npm install && node --test test/*.test.js` — pass
- `npm install --prefix ui-prototype && npm run build --prefix ui-prototype` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deeeabf7-5696-48cc-be38-1a89cb8413ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deeeabf7-5696-48cc-be38-1a89cb8413ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

