### PR TITLE
Fix npm test to use shell-agnostic Node discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "sync": "node automerge-sync-server.js",
-    "test": "node --test --test-isolation=none test/*.test.js",
+    "test": "node --test --test-isolation=none",
     "daemon": "node daemon/index.js",
     "ui:build": "npm run build --prefix ui-prototype",
     "smoke:automerge": "node scripts/smoke/automerge-smoke.js",


### PR DESCRIPTION
## Summary
- update the root `test` script to use `node --test --test-isolation=none`
- remove reliance on shell glob expansion for `test/*.test.js`
- preserve the existing test suite shape and isolation behavior

## Testing
- `node --test --test-isolation=none`
- `npm test`