### PR TITLE
Enforce sync-server runtime and add HTTP task commit linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Task tracking and coordination system built on Automerge CRDTs. Replaces beans w
               ┌─────────────────┼─────────────────┐
               ▼                 ▼                 ▼
         ┌─────────┐      ┌───────────┐     ┌──────────┐
-        │ mc CLI  │      │ Sync Srv  │     │ UI Proto │
+        │ mc CLI  │      │ Sync Srv  │     │ UI Dev   │
         └─────────┘      └───────────┘     └──────────┘
 ```
 
@@ -28,18 +28,20 @@ Task tracking and coordination system built on Automerge CRDTs. Replaces beans w
 | Component | Location | Purpose |
 |-----------|----------|---------|
 | **mc CLI** | `bin/mc.js` | Primary interface for task management |
-| **Automerge Store** | `lib/automerge-store.js` | CRDT-based persistent storage |
-| **Sync Server** | `automerge-sync-server.js` | Canonical HTTP/WebSocket runtime |
-| **Notification Daemon** | `daemon/index.js` | Mention delivery worker |
-| **UI Prototype** | `ui-prototype/src/MissionControlSync.jsx` | React dashboard client |
+| **Automerge Store** | `lib/automerge-store.js` | Internal persistence layer behind the sync server |
+| **Sync Server** | `automerge-sync-server.js` | Supported HTTP/WebSocket state authority |
+| **Notification Daemon** | `daemon/index.js` | Supported mention-delivery worker |
+| **UI Dev Client** | `ui-prototype/src/MissionControlSync.jsx` | Supported development UI client |
 
-### Supported Runtime Paths
+### Supported Runtime
 
 Mission Control supports one runtime architecture:
 
 1. Start `automerge-sync-server.js` (HTTP + WebSocket state authority).
 2. Point CLI/daemon to that server (`MC_SYNC_SERVER` or `MC_HTTP_PORT`).
 3. Run UI through Vite proxy (`/mc-api` + `/mc-ws`).
+
+Anything that bypasses the sync server, including direct local-store access from CLI workflows, is not a supported runtime path.
 
 ## CLI Reference
 
@@ -92,11 +94,11 @@ npm install
 # Symlink for easy access
 ln -s $(pwd)/bin/mc.js ~/bin/mc
 
-# Start sync server (required for shared runtime)
+# Start the supported runtime state authority
 export MC_API_TOKEN="$(openssl rand -hex 32)"
 MC_API_TOKEN="$MC_API_TOKEN" npm run sync
 
-# List tasks
+# Use the CLI with the same token
 MC_API_TOKEN="$MC_API_TOKEN" mc tasks
 
 # Create a task
@@ -107,6 +109,10 @@ MC_API_TOKEN="$MC_API_TOKEN" mc comment <task-id> "Working on this now"
 
 # Check activity
 MC_API_TOKEN="$MC_API_TOKEN" mc activity --limit 10
+
+# Optional supported workers/clients
+MC_API_TOKEN="$MC_API_TOKEN" npm run daemon
+VITE_MC_API_TOKEN="$MC_API_TOKEN" npm run dev --prefix ui-prototype
 ```
 
 ## Data Storage
@@ -159,7 +165,7 @@ Optional compatibility setting:
 Behavior notes:
 - Browser requests with an `Origin` header must match `MC_ALLOWED_ORIGINS`. Allowed preflight `OPTIONS` requests receive the same allowlisted CORS headers; disallowed origins are rejected with `403`.
 - Originless non-browser requests (for example CLI and daemon traffic) are allowed and still require auth unless `MC_ALLOW_INSECURE_LOCAL=1` is set.
-- CLI fallback to the local Automerge store only happens when the sync server is unreachable at the transport layer. If the server is reachable and returns `401`, `403`, `404`, or `500`, the CLI fails instead of bypassing server auth or policy.
+- CLI and daemon commands fail fast when the sync server is unreachable; they do not fall back to direct local-store access.
 - The sync server logs rejected auth/origin checks with a `[security]` prefix and keeps in-memory counters for HTTP and WebSocket rejections, which are exposed for integration tests and runtime diagnostics.
 
 ## Migration from Beans
@@ -176,14 +182,9 @@ npm test
 # Install UI dependencies once, then verify the Vite build from repo root
 npm install --prefix ui-prototype
 npm run ui:build
-
-# Smoke scripts (manual/runtime checks)
-npm run smoke:automerge
-npm run smoke:cli
-
-# Report against an existing migrated document URL
-MC_TEST_DOC_URL="<automerge-url>" npm run smoke:migrated
 ```
+
+Archived migration/demo scripts under `scripts/smoke/` are retained for internal reference only and are not part of the supported runtime flow.
 
 ### Sync Server
 ```bash
@@ -203,7 +204,7 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for details.
 - ✅ Real-time sync (WebSocket)
 - ✅ Patchwork timeline/branching
 - ✅ Agent Trace (commit attribution)
-- 🔄 UI prototype (built, not deployed)
+- 🔄 UI development client (built, not deployed)
 
 ## License
 

--- a/automerge-sync-server.js
+++ b/automerge-sync-server.js
@@ -2,9 +2,9 @@
 
 /**
  * Automerge Sync Server
- * 
- * Bridges frontend Automerge (browser) with backend AutomergeStore (Node.js)
- * Provides real-time sync between UI and backend data persistence
+ *
+ * Supported runtime state authority for Mission Control.
+ * CLI, daemon, and UI clients all talk to this process.
  */
 
 import { WebSocketServer } from 'ws'
@@ -601,6 +601,28 @@ class AutomergeSyncServer {
         const { taskId } = req.params
         const history = await this.store.getTaskHistory(taskId)
         res.json({ history })
+      } catch (error) {
+        res.status(500).json({ error: error.message })
+      }
+    })
+
+    // ─── Patchwork: Link Commit ───
+    this.app.post('/automerge/task/:taskId/commit', async (req, res) => {
+      try {
+        const { taskId } = req.params
+        const { commit, agent } = req.body
+        const doc = this.store.getDoc()
+
+        if (!commit?.hash || !commit?.message) {
+          return res.status(400).json({ error: 'commit.hash and commit.message are required' })
+        }
+        if (!doc.tasks?.[taskId]) {
+          return res.status(404).json({ error: `Task ${taskId} not found` })
+        }
+
+        await this.store.recordCommit(taskId, commit, agent || 'api')
+        this.broadcastDocumentUpdate()
+        res.json({ success: true, taskId, commitHash: commit.hash })
       } catch (error) {
         res.status(500).json({ error: error.message })
       }

--- a/bin/mc.js
+++ b/bin/mc.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 /**
- * Mission Control CLI (HTTP-first, Automerge backend)
- * 
- * Uses sync server HTTP API by default to prevent split-brain.
- * Falls back to direct store access only when sync server unavailable.
- * 
+ * Mission Control CLI
+ *
+ * Supported runtime path:
+ * - automerge-sync-server.js is the state authority
+ * - CLI commands talk to the sync server over HTTP
+ * - UI connects through the sync server's HTTP/WebSocket APIs
+ *
  * Usage:
  *   mc comment <task-id> "message"
  *   mc comments <task-id>
@@ -29,7 +31,6 @@
  *   mc trace task <task-id>              Show commits linked to a task
  */
 
-import { AutomergeStore } from '../lib/automerge-store.js';
 import * as agentTrace from '../lib/agent-trace.js';
 import { SyncRequestError, requestJson } from '../lib/sync-client.js';
 import { activityTaskId } from '../lib/activity-task-id.js';
@@ -54,23 +55,21 @@ function positionalArgs() {
   return result;
 }
 
-// Lazy-loaded store (only init when HTTP unavailable)
-let _store = null;
-async function getStore() {
-  if (!_store) {
-    _store = new AutomergeStore();
-    await _store.init();
-  }
-  return _store;
-}
-
-async function getLocalDoc() {
-  const store = await getStore();
-  return store.getDoc();
-}
-
 function isTransportFailure(error) {
   return error instanceof SyncRequestError && error.isTransport;
+}
+
+function printSyncRuntimeHint() {
+  console.error(`   Sync server: ${API_BASE}`);
+  console.error('   Start the supported runtime with `npm run sync`, or make sure MC_SYNC_SERVER points to a reachable server.');
+  console.error('   If auth is enabled, use the same MC_API_TOKEN for the server and this command.');
+}
+
+function printCommandError(prefix, error) {
+  console.error(`${prefix}: ${error.message}`);
+  if (isTransportFailure(error)) {
+    printSyncRuntimeHint();
+  }
 }
 
 async function apiRequest(path, options = {}) {
@@ -109,68 +108,36 @@ async function apiDelete(path) {
   return apiRequest(path, { method: 'DELETE' });
 }
 
-async function withStoreFallback(requestFn, fallbackFn) {
-  try {
-    return await requestFn();
-  } catch (error) {
-    if (!isTransportFailure(error)) throw error;
-    return fallbackFn(error);
-  }
-}
-
-// Get document via HTTP (preferred) or fallback to store only on transport errors.
 async function getDoc() {
-  const data = await withStoreFallback(
-    () => apiGet('/automerge/doc'),
-    async () => ({ success: true, doc: await getLocalDoc() })
-  );
-
+  const data = await apiGet('/automerge/doc');
   if (data.success && data.doc) return data.doc;
   throw new Error('Invalid document response from sync server');
 }
 
-async function addCommentWithFallback(taskId, text, agent) {
-  return withStoreFallback(
-    async () => {
-      const data = await apiPost('/automerge/comment', { taskId, text, agent });
-      return { commentId: data.commentId, viaStore: false };
-    },
-    async () => {
-      const store = await getStore();
-      const commentId = await store.addComment(taskId, text, agent);
-      return { commentId, viaStore: true };
-    }
-  );
+async function addComment(taskId, text, agent) {
+  const data = await apiPost('/automerge/comment', { taskId, text, agent });
+  return { commentId: data.commentId };
 }
 
-async function getPendingMentionsWithFallback(agent) {
+async function getPendingMentions(agent) {
   const url = agent
     ? `/automerge/mentions/pending?agent=${encodeURIComponent(agent)}`
     : '/automerge/mentions/pending';
 
-  return withStoreFallback(
-    async () => {
-      const data = await apiGet(url);
-      return data.mentions || [];
-    },
-    async () => {
-      const store = await getStore();
-      return store.getPendingMentions(agent);
-    }
-  );
+  const data = await apiGet(url);
+  return data.mentions || [];
 }
 
-async function getTaskHistoryWithFallback(taskId) {
-  return withStoreFallback(
-    async () => {
-      const data = await apiGet(`/automerge/task/${taskId}/history`);
-      return data.history || [];
-    },
-    async () => {
-      const store = await getStore();
-      return store.getTaskHistory(taskId);
-    }
-  );
+async function getTaskHistory(taskId) {
+  const data = await apiGet(`/automerge/task/${taskId}/history`);
+  return data.history || [];
+}
+
+async function ensureTaskLinkReady(taskId) {
+  const doc = await getDoc();
+  if (!doc.tasks?.[taskId]) {
+    throw new Error(`Task ${taskId} not found on sync server`);
+  }
 }
 
 function usage() {
@@ -259,11 +226,10 @@ async function main() {
     process.exit(0);
   }
 
-  try {
-    // ─────────────────────────────────────────
-    // mc comment <task-id> "message"
-    // ─────────────────────────────────────────
-    if (command === 'comment') {
+  // ─────────────────────────────────────────
+  // mc comment <task-id> "message"
+  // ─────────────────────────────────────────
+  if (command === 'comment') {
       const posArgs = positionalArgs();
       const taskId = posArgs[1];
       const message = posArgs[2];
@@ -274,8 +240,8 @@ async function main() {
         process.exit(1);
       }
       
-      const result = await addCommentWithFallback(taskId, message, agent);
-      console.log(`✅ Comment added: ${result.commentId}${result.viaStore ? ' (via store)' : ''}`);
+      const result = await addComment(taskId, message, agent);
+      console.log(`✅ Comment added: ${result.commentId}`);
       
       const mentions = message.match(/@(\w+)/g) || [];
       if (mentions.length > 0) {
@@ -345,7 +311,7 @@ async function main() {
         agent = getArg('agent');
       }
       
-      const mentions = await getPendingMentionsWithFallback(agent);
+      const mentions = await getPendingMentions(agent);
       
       if (mentions.length === 0) {
         console.log('No pending mentions.');
@@ -587,7 +553,7 @@ async function main() {
       
       // Use HTTP API for history
       try {
-        const history = await getTaskHistoryWithFallback(taskId);
+        const history = await getTaskHistory(taskId);
         
         // Merge API history with commit history from Patchwork
         const doc = await getDoc();
@@ -638,7 +604,7 @@ async function main() {
           console.log();
         }
       } catch (e) {
-        console.error(`❌ Failed to get history: ${e.message}`);
+        printCommandError('❌ Failed to get history', e);
         process.exit(1);
       }
     }
@@ -680,7 +646,7 @@ async function main() {
           console.log(`   ${c.field}: ${c.old || '(none)'} → ${c.new}`);
         }
       } catch (e) {
-        console.error(`❌ Failed: ${e.message}`);
+        printCommandError('❌ Failed', e);
         process.exit(1);
       }
     }
@@ -708,7 +674,7 @@ async function main() {
           console.log(`\n   Work on the branch, then merge with: mc merge ${result.branchId}`);
         }
       } catch (e) {
-        console.error(`❌ Failed to create branch: ${e.message}`);
+        printCommandError('❌ Failed to create branch', e);
         process.exit(1);
       }
     }
@@ -742,7 +708,7 @@ async function main() {
           }
         }
       } catch (e) {
-        console.error(`❌ Failed to list branches: ${e.message}`);
+        printCommandError('❌ Failed to list branches', e);
         process.exit(1);
       }
     }
@@ -765,7 +731,7 @@ async function main() {
         console.log(`   ${branchId} → ${result.parentId}`);
         console.log(`   Changes applied to parent task`);
       } catch (e) {
-        console.error(`❌ Failed to merge: ${e.message}`);
+        printCommandError('❌ Failed to merge', e);
         process.exit(1);
       }
     }
@@ -794,8 +760,7 @@ async function main() {
         if (assignee) console.log(`   Assignee: @${assignee}`);
         if (tags.length) console.log(`   Tags: ${tags.join(', ')}`);
       } catch (e) {
-        console.error(`❌ Failed: ${e.message}`);
-        console.error('   Is the sync server running? (pm2 start mc-sync)');
+        printCommandError('❌ Failed', e);
         process.exit(1);
       }
     }
@@ -817,6 +782,15 @@ async function main() {
       const agent = getArg('agent', process.env.MC_AGENT || 'unknown');
       const model = getArg('model', process.env.OPENCLAW_MODEL || null);
       const sessionKey = getArg('session', process.env.OPENCLAW_SESSION_KEY || null);
+
+      if (taskId) {
+        try {
+          await ensureTaskLinkReady(taskId);
+        } catch (err) {
+          printCommandError('❌ Cannot link commit to task', err);
+          process.exit(1);
+        }
+      }
       
       // Build git args (remove our custom flags)
       const gitArgs = [];
@@ -848,7 +822,7 @@ async function main() {
       }
       
       // Create trace record
-      const { filepath, trace } = agentTrace.createTrace({
+      const { trace } = agentTrace.createTrace({
         repoPath,
         commitHash: commitInfo.hash,
         commitMessage: commitInfo.message,
@@ -868,18 +842,21 @@ async function main() {
       // Link commit to Patchwork timeline if task specified
       if (taskId) {
         try {
-          const store = new AutomergeStore();
-          await store.init();
-          await store.recordCommit(taskId, {
-            hash: commitInfo.hash,
-            message: commitInfo.message,
-            diff: diffStats
-          }, agent);
-          await store.close();
+          await apiPost(`/automerge/task/${taskId}/commit`, {
+            commit: {
+              hash: commitInfo.hash,
+              message: commitInfo.message,
+              diff: diffStats
+            },
+            agent
+          });
           console.log(`   📎 Linked to Patchwork timeline`);
         } catch (err) {
-          // Non-fatal — trace is already saved
-          console.error(`   ⚠️  Could not link to Patchwork: ${err.message}`);
+          console.error(`❌ Commit created, but Mission Control was not updated: ${err.message}`);
+          if (isTransportFailure(err)) {
+            printSyncRuntimeHint();
+          }
+          process.exit(1);
         }
       }
     }
@@ -973,9 +950,7 @@ async function main() {
         process.exit(1);
       }
       
-      // Use direct store to ensure we see latest commits
-      const store = await getStore();
-      const doc = store.getDoc();
+      const doc = await getDoc();
       const history = ((doc.taskHistory || {})[taskId] || [])
         .filter(h => h.type === 'commit');
       
@@ -1000,19 +975,14 @@ async function main() {
       }
     }
 
-    else {
-      console.error(`Unknown command: ${command}`);
-      usage();
-      process.exit(1);
-    }
-  } finally {
-    if (_store) {
-      await _store.close();
-    }
+  else {
+    console.error(`Unknown command: ${command}`);
+    usage();
+    process.exit(1);
   }
 }
 
 main().catch(err => {
-  console.error('Error:', err.message);
+  printCommandError('Error', err);
   process.exit(1);
 });

--- a/daemon/index.js
+++ b/daemon/index.js
@@ -2,9 +2,9 @@
 
 /**
  * Mission Control Notification Daemon v2
- * 
- * Uses the Automerge Sync Server HTTP API for real-time state.
- * Polls for pending mentions and delivers via OpenClaw cron wake.
+ *
+ * Supported runtime worker for Mission Control.
+ * Polls the sync server for pending mentions and delivers them via OpenClaw cron wake.
  */
 
 import { requestJson } from '../lib/sync-client.js'
@@ -22,6 +22,11 @@ function log(msg) {
 
 function debug(msg) {
   if (VERBOSE) log(`[debug] ${msg}`);
+}
+
+function printSupportedRuntimeHint() {
+  log('   Start the supported runtime with `npm run sync`, or make sure MC_SYNC_SERVER points to a reachable server.')
+  log('   If auth is enabled, run the daemon with the same MC_API_TOKEN as the sync server.')
 }
 
 async function getDocument() {
@@ -125,7 +130,7 @@ async function runDaemon() {
     log(`   Agents: ${agentCount}, Pending mentions: ${pendingCount}`);
   } catch (err) {
     log(`❌ Cannot connect to sync server: ${err.message}`);
-    log(`   Make sure mc-sync is running: pm2 start automerge-sync-server.js --name mc-sync`);
+    printSupportedRuntimeHint();
     process.exit(1);
   }
   

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,8 +21,8 @@
 - [x] Branch/merge for task experimentation
 - [x] Diff visualization
 
-### Phase 4: UI Prototype
-- [x] React dashboard (`ui-prototype/`)
+### Phase 4: UI Development Client
+- [x] React dashboard dev client (`ui-prototype/`)
 - [x] Task board with sync
 - [x] Activity feed view
 
@@ -30,16 +30,17 @@
 
 ## Current State (2026-02-08)
 
-**Architecture:** Single-agent (Gary) using Mission Control for task tracking.
+**Architecture:** Single supported runtime path with the sync server as state authority for CLI, daemon, and UI clients.
+**Operating Model:** Single-agent (Gary) using Mission Control for task tracking.
 **Storage:** 65 tasks in Automerge store
-**Status:** Functional, beans deprecated
+**Status:** Functional, beans deprecated, UI shipped as a supported development client
 
 ---
 
 ## Future Work (Unprioritized)
 
 ### Polish & Stability
-- [ ] Deploy UI to production (currently prototype only)
+- [ ] Productionize UI deployment (current repo ships a development client)
 - [ ] Add `--json` output to CLI for scripting
 - [ ] Timestamp tracking for stale task detection
 - [ ] Backup/export functionality

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "sync": "node automerge-sync-server.js",
     "test": "node --test --test-isolation=none",
     "daemon": "node daemon/index.js",
-    "ui:build": "npm run build --prefix ui-prototype",
-    "smoke:automerge": "node scripts/smoke/automerge-smoke.js",
-    "smoke:cli": "node scripts/smoke/cli-integration-smoke.js",
-    "smoke:migrated": "node scripts/smoke/migrated-data-report.js"
+    "ui:build": "npm run build --prefix ui-prototype"
   },
   "keywords": [
     "mission-control",

--- a/scripts/smoke/automerge-smoke.js
+++ b/scripts/smoke/automerge-smoke.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Test script for Automerge store
- * Verifies core functionality and real-time sync capabilities
+ * Internal archived script.
+ * Kept for migration/demo reference only; not part of the supported runtime flow.
  */
 
 import { AutomergeStore } from '../../lib/automerge-store.js'

--- a/scripts/smoke/cli-integration-smoke.js
+++ b/scripts/smoke/cli-integration-smoke.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Test Integration: MC CLI with Automerge Backend
- * Shows how current CLI commands could work with new store
+ * Internal archived script.
+ * Kept for migration/demo reference only; not part of the supported runtime flow.
  */
 
 import { AutomergeStore } from '../../lib/automerge-store.js'

--- a/scripts/smoke/migrated-data-report.js
+++ b/scripts/smoke/migrated-data-report.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Test Mission Control with real migrated data
+ * Internal archived script.
+ * Kept for migration/demo reference only; not part of the supported runtime flow.
  */
 
 import { AutomergeStore } from '../../lib/automerge-store.js'

--- a/test/automerge-sync-server.test.js
+++ b/test/automerge-sync-server.test.js
@@ -335,3 +335,51 @@ it('allows legacy websocket query tokens only when the compatibility flag is ena
     await once(enabledSocket, 'close')
   })
 })
+
+it('records task-linked commits through the HTTP API', async () => {
+  await withStartedServer({}, async server => {
+    await server.store.docHandle.change(doc => {
+      if (!doc.tasks) doc.tasks = {}
+      doc.tasks['task-123'] = {
+        id: 'task-123',
+        title: 'Track commit through server API',
+        status: 'todo',
+        priority: 'p2',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }
+    })
+
+    const response = await fetch(httpUrl(server, '/automerge/task/task-123/commit'), {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer secret-token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        agent: 'codex',
+        commit: {
+          hash: '1234567890abcdef',
+          message: 'Link commit through supported runtime',
+          diff: { shortstat: '1 file changed' },
+        },
+      }),
+    })
+
+    assert.equal(response.status, 200)
+    assert.equal((await response.json()).success, true)
+
+    const doc = server.store.getDoc()
+    const history = doc.taskHistory?.['task-123'] || []
+    const commitEntry = history.find(entry => entry.type === 'commit')
+    assert.ok(commitEntry)
+    assert.equal(commitEntry.agent, 'codex')
+    assert.equal(commitEntry.commit.hash, '1234567890abcdef')
+
+    const commitActivity = (doc.activity || []).find(
+      entry => entry.type === 'commit_linked' && entry.taskId === 'task-123'
+    )
+    assert.ok(commitActivity)
+    assert.equal(commitActivity.agent, 'codex')
+  })
+})

--- a/test/mc-cli-auth-fallback.test.js
+++ b/test/mc-cli-auth-fallback.test.js
@@ -2,9 +2,9 @@
 
 import { afterEach, describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { spawn } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import { createServer } from 'node:http'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -56,16 +56,19 @@ async function readStore(cwd) {
   return doc
 }
 
+async function startJsonServer(handler) {
+  const server = createServer(handler)
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  stubServers.push(server)
+  return `http://127.0.0.1:${server.address().port}`
+}
+
 async function startStubServer(statusCode, errorMessage) {
-  const server = createServer((req, res) => {
+  return startJsonServer((req, res) => {
     res.statusCode = statusCode
     res.setHeader('Content-Type', 'application/json')
     res.end(JSON.stringify({ error: errorMessage }))
   })
-
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
-  stubServers.push(server)
-  return `http://127.0.0.1:${server.address().port}`
 }
 
 async function reserveUnusedPort() {
@@ -74,6 +77,30 @@ async function reserveUnusedPort() {
   const port = server.address().port
   await new Promise(resolve => server.close(resolve))
   return port
+}
+
+function createGitRepoWithStagedChange(prefix = 'mc-cli-commit-repo-') {
+  const cwd = createTempDir(prefix)
+  execSync('git init', { cwd, stdio: 'pipe' })
+  execSync('git config user.email "test@example.com"', { cwd, stdio: 'pipe' })
+  execSync('git config user.name "Test User"', { cwd, stdio: 'pipe' })
+
+  writeFileSync(join(cwd, 'note.txt'), 'initial\n')
+  execSync('git add note.txt', { cwd, stdio: 'pipe' })
+  execSync('git commit -m "Initial commit"', { cwd, stdio: 'pipe' })
+
+  writeFileSync(join(cwd, 'note.txt'), 'changed\n')
+  execSync('git add note.txt', { cwd, stdio: 'pipe' })
+
+  return cwd
+}
+
+function gitCommitCount(cwd) {
+  return Number(execSync('git rev-list --count HEAD', {
+    cwd,
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  }).trim())
 }
 
 function runCli(cwd, args, env = {}) {
@@ -125,7 +152,7 @@ afterEach(async () => {
   }
 })
 
-describe('mc CLI sync-server fallback hardening', () => {
+describe('mc CLI supported runtime enforcement', () => {
   it('does not fall back to the local store for reachable server HTTP errors on read commands', async () => {
     const cwd = createTempDir()
     await seedTaskStore(cwd)
@@ -162,7 +189,7 @@ describe('mc CLI sync-server fallback hardening', () => {
     assert.equal(Object.keys(doc.comments || {}).length, 0)
   })
 
-  it('falls back to the local store when the sync server is unreachable for read commands', async () => {
+  it('fails with supported-runtime guidance when the sync server is unreachable for read commands', async () => {
     const cwd = createTempDir()
     await seedTaskStore(cwd)
     const unusedPort = await reserveUnusedPort()
@@ -171,11 +198,14 @@ describe('mc CLI sync-server fallback hardening', () => {
       MC_SYNC_SERVER: `http://127.0.0.1:${unusedPort}`,
     })
 
-    assert.equal(result.status, 0)
-    assert.match(result.stdout, /Local fallback task/)
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Could not reach sync server/)
+    assert.match(result.stderr, /npm run sync/)
+    assert.match(result.stderr, /MC_API_TOKEN/)
+    assert.doesNotMatch(result.stdout, /Local fallback task/)
   })
 
-  it('falls back to the local store when the sync server is unreachable for comment writes', async () => {
+  it('fails with supported-runtime guidance when the sync server is unreachable for comment writes', async () => {
     const cwd = createTempDir()
     await seedTaskStore(cwd)
     const unusedPort = await reserveUnusedPort()
@@ -185,14 +215,95 @@ describe('mc CLI sync-server fallback hardening', () => {
       MC_AGENT: 'gary',
     })
 
-    assert.equal(result.status, 0)
-    assert.match(result.stdout, /\(via store\)/)
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Could not reach sync server/)
+    assert.match(result.stderr, /npm run sync/)
+    assert.match(result.stderr, /MC_API_TOKEN/)
 
     const doc = await readStore(cwd)
     const comments = Object.values(doc.comments || {})
-    assert.equal(comments.length, 1)
-    assert.equal(comments[0].content, 'offline comment')
-    assert.equal(comments[0].taskId, 'local-task-1')
-    assert.ok(!('task_id' in comments[0]))
+    assert.equal(comments.length, 0)
+  })
+
+  it('does not create a git commit when the sync server is unreachable for task-linked commits', async () => {
+    const cwd = createGitRepoWithStagedChange()
+    const unusedPort = await reserveUnusedPort()
+
+    const before = gitCommitCount(cwd)
+    const result = await runCli(cwd, ['commit', '--task', 'task-123', '-m', 'blocked task link'], {
+      MC_SYNC_SERVER: `http://127.0.0.1:${unusedPort}`,
+      MC_AGENT: 'gary',
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Could not reach sync server/)
+    assert.equal(gitCommitCount(cwd), before)
+  })
+
+  it('does not create a git commit when the requested task is missing on the sync server', async () => {
+    const cwd = createGitRepoWithStagedChange()
+    const baseUrl = await startJsonServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/automerge/doc') {
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ success: true, doc: { tasks: {} } }))
+        return
+      }
+
+      res.statusCode = 404
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Not found' }))
+    })
+
+    const before = gitCommitCount(cwd)
+    const result = await runCli(cwd, ['commit', '--task', 'task-404', '-m', 'missing task'], {
+      MC_SYNC_SERVER: baseUrl,
+      MC_AGENT: 'gary',
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Task task-404 not found on sync server/)
+    assert.equal(gitCommitCount(cwd), before)
+  })
+
+  it('returns a non-zero exit when post-commit task linking fails', async () => {
+    const cwd = createGitRepoWithStagedChange()
+    const baseUrl = await startJsonServer((req, res) => {
+      if (req.method === 'GET' && req.url === '/automerge/doc') {
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({
+          success: true,
+          doc: {
+            tasks: {
+              'task-123': { id: 'task-123', title: 'Server task' },
+            },
+          },
+        }))
+        return
+      }
+
+      if (req.method === 'POST' && req.url === '/automerge/task/task-123/commit') {
+        res.statusCode = 500
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Link write failed' }))
+        return
+      }
+
+      res.statusCode = 404
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Not found' }))
+    })
+
+    const before = gitCommitCount(cwd)
+    const result = await runCli(cwd, ['commit', '--task', 'task-123', '-m', 'commit link fails'], {
+      MC_SYNC_SERVER: baseUrl,
+      MC_AGENT: 'gary',
+    })
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Mission Control was not updated/)
+    assert.match(result.stderr, /Link write failed/)
+    assert.equal(gitCommitCount(cwd), before + 1)
   })
 })

--- a/ui-prototype/src/main.jsx
+++ b/ui-prototype/src/main.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import MissionControlSync from './MissionControlSync'
 
-// Mission Control with Automerge Sync Layer
-// Connects to backend sync server for real-time collaboration
-console.log('🚀 Mission Control: Starting with Automerge Sync Layer')
+// Mission Control development client.
+// Connects to the supported sync-server runtime for real-time collaboration.
+console.log('🚀 Mission Control: Starting development client against sync server')
 
 // Mount the app
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- remove CLI local-store fallback paths and fail fast with clearer sync-server guidance for CLI and daemon commands
- add an HTTP endpoint for linking commits to task history so `mc commit --task` updates Mission Control through the supported runtime
- update tests to cover unreachable server, missing task, and post-commit link failure cases
- refresh docs and roadmap language to describe the sync server as the supported runtime and archive old smoke scripts

## Testing
- `npm test`