### PR TITLE
fix(ui): Mission Control no longer stuck on Connecting after WS reconnect

### DIFF
--- a/ui-prototype/src/MissionControlSync.jsx
+++ b/ui-prototype/src/MissionControlSync.jsx
@@ -25,6 +25,8 @@ export default function MissionControlSync() {
   const [mobileActiveColumn, setMobileActiveColumn] = useState('in-progress')
   const [view, setView] = useState('board') // 'board' or 'activity'
   const wsRef = useRef(null)
+  // connectToSyncServer is only ever the first-render fn (effect + onclose retry); doc in that closure is always null.
+  const hasReceivedDocRef = useRef(false)
   
   useEffect(() => {
     connectToSyncServer()
@@ -38,7 +40,8 @@ export default function MissionControlSync() {
   }, [])
   
   const connectToSyncServer = async () => {
-    setLoading(true)
+    setError(null)
+    if (!hasReceivedDocRef.current) setLoading(true)
     if (wsRef.current) wsRef.current.close()
     try {
       const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -47,8 +50,16 @@ export default function MissionControlSync() {
       wsRef.current = ws
       ws.onopen = () => { setConnected(true); setError(null) }
       ws.onmessage = (event) => {
-        const message = JSON.parse(event.data)
+        let message
+        try {
+          message = JSON.parse(event.data)
+        } catch {
+          setError('Invalid sync message from server')
+          if (!hasReceivedDocRef.current) setLoading(false)
+          return
+        }
         if (message.type === 'document-state' || message.type === 'document-update') {
+          hasReceivedDocRef.current = true
           setDoc(message.doc)
           setLoading(false)
           // Update selected task if it changed
@@ -58,7 +69,10 @@ export default function MissionControlSync() {
         }
       }
       ws.onclose = () => { setConnected(false); setTimeout(connectToSyncServer, 3000) }
-      ws.onerror = () => setError('Connection failed')
+      ws.onerror = () => {
+        setError('Connection failed')
+        if (!hasReceivedDocRef.current) setLoading(false)
+      }
     } catch (error) { setError(error.message); setLoading(false) }
   }
 
@@ -105,7 +119,17 @@ export default function MissionControlSync() {
   }
   
   if (loading) return <div style={styles.centered}><div style={styles.spinner} /><p style={styles.loadingText}>Connecting...</p></div>
-  if (!doc) return <div style={styles.centered}><p style={styles.loadingText}>Loading...</p></div>
+  if (!doc) {
+    if (error) {
+      return (
+        <div style={styles.centered}>
+          <p style={{ ...styles.loadingText, color: '#fecaca', marginBottom: 16 }}>{error}</p>
+          <button type="button" style={styles.btnPrimary} onClick={() => connectToSyncServer()}>Retry</button>
+        </div>
+      )
+    }
+    return <div style={styles.centered}><p style={styles.loadingText}>Loading...</p></div>
+  }
   
   const tasks = Object.values(doc.tasks || {})
   const agents = Object.values(doc.agents || {})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Mission Control UI showed the full-page **Connecting…** spinner indefinitely after any WebSocket disconnect/reconnect.

## Root cause

`connectToSyncServer` is created once and reused by the initial `useEffect` and by `ws.onclose`’s `setTimeout(connectToSyncServer, 3000)`. That function **always closes over the first render**, where `doc` is `null`. On every reconnect it called `setLoading(true)`, so `loading` stayed true even though `doc` was already populated—React kept rendering the spinner branch and never showed the board.

## Changes

- Use `hasReceivedDocRef` so we only enter full-page loading before the first `document-state` / `document-update`.
- On `WebSocket` error, clear `loading` when still waiting for the first document (so the error UI can show).
- Guard `JSON.parse` in `onmessage` so bad payloads do not leave the UI stuck.
- When `doc` is still null but there is an error, show the message plus a **Retry** button.

## Verification

- `npm test` (all 124 tests pass).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47304605-e48c-4bbc-9d7c-3f7c7de2ce0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47304605-e48c-4bbc-9d7c-3f7c7de2ce0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

