### PR TITLE
fix: atomic task PATCH via AutomergeStore.updateTask

### DIFF
--- a/automerge-sync-server.js
+++ b/automerge-sync-server.js
@@ -541,58 +541,26 @@ class AutomergeSyncServer {
       try {
         const { taskId } = req.params
         const { status, assignee, title, description, priority, agent } = req.body
-        
-        const doc = this.store.getDoc()
-        if (!doc.tasks?.[taskId]) {
-          return res.status(404).json({ error: `Task ${taskId} not found` })
+
+        const updates = {}
+        if (status !== undefined) updates.status = status
+        if (assignee !== undefined) updates.assignee = assignee || null
+        if (title !== undefined) updates.title = title
+        if (description !== undefined) updates.description = description
+        if (priority !== undefined) updates.priority = priority
+
+        const result = await this.store.updateTask(taskId, updates, agent || 'api')
+        if (!result.success) {
+          if (result.error === 'Task not found') {
+            return res.status(404).json({ error: `Task ${taskId} not found` })
+          }
+          return res.status(500).json({ error: result.error || 'Task update failed' })
         }
-        
-        const changes = []
-        
-        await this.store.docHandle.change(doc => {
-          if (status && doc.tasks[taskId].status !== status) {
-            changes.push({ field: 'status', old: doc.tasks[taskId].status, new: status })
-            doc.tasks[taskId].status = status
-          }
-          if (assignee !== undefined && doc.tasks[taskId].assignee !== assignee) {
-            changes.push({ field: 'assignee', old: doc.tasks[taskId].assignee, new: assignee })
-            doc.tasks[taskId].assignee = assignee || null
-          }
-          if (title && doc.tasks[taskId].title !== title) {
-            changes.push({ field: 'title', old: doc.tasks[taskId].title, new: title })
-            doc.tasks[taskId].title = title
-          }
-          if (description !== undefined && doc.tasks[taskId].description !== description) {
-            changes.push({ field: 'description', old: doc.tasks[taskId].description, new: description })
-            doc.tasks[taskId].description = description
-          }
-          if (priority && doc.tasks[taskId].priority !== priority) {
-            changes.push({ field: 'priority', old: doc.tasks[taskId].priority, new: priority })
-            doc.tasks[taskId].priority = priority
-          }
-          
-          if (changes.length > 0) {
-            doc.tasks[taskId].updated_at = new Date().toISOString()
-            
-            if (!doc.activity) doc.activity = []
-            doc.activity.push({
-              id: Math.random().toString(16).slice(2),
-              type: 'task_updated',
-              agent: agent || 'api',
-              taskId,
-              // Detailed changes tracked in taskHistory, not here
-              timestamp: new Date().toISOString()
-            })
-          }
-        })
-        
-        // Record to taskHistory for Patchwork diff tracking
-        if (changes.length > 0) {
-          await this.store.recordTaskChange(taskId, changes, agent || 'api')
+
+        if (result.changes.length > 0) {
+          this.broadcastDocumentUpdate()
         }
-        
-        this.broadcastDocumentUpdate()
-        res.json({ success: true, taskId, changes })
+        res.json({ success: true, taskId, changes: result.changes })
       } catch (error) {
         res.status(500).json({ error: error.message })
       }

--- a/lib/automerge-store.js
+++ b/lib/automerge-store.js
@@ -632,6 +632,7 @@ export class AutomergeStore {
       })
       
       // Log activity
+      if (!doc.activity) doc.activity = []
       doc.activity.push({
         id: genId('a'),
         type: 'task_updated',

--- a/test/fitness-gaps.test.js
+++ b/test/fitness-gaps.test.js
@@ -242,20 +242,13 @@ describe('GAP: mention delivery duplicate protection', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────
-// GAP 3: PATCH endpoint computes diff outside the atomic change
+// GAP: task PATCH atomicity (regression guard)
 //
-// In automerge-sync-server.js, PATCH /automerge/task/:taskId reads
-// the current doc via store.getDoc() (a snapshot), computes which
-// fields changed, then enters docHandle.change() to apply them.
-// The diff computation and the write are NOT in the same atomic
-// block. The HTTP handler also records changes in two separate
-// docHandle.change() calls (one for the update, one via
-// recordTaskChange for history) — meaning another request could
-// interleave between them.
-//
-// This test verifies that the update AND its history entry are
-// recorded atomically. Today they aren't — the update and the
-// history write are separate docHandle.change() calls.
+// PATCH /automerge/task/:taskId delegates to AutomergeStore.updateTask(),
+// which applies task fields, taskHistory, and task_updated activity inside
+// a single docHandle.change(). This suite guards that one mutating PATCH
+// still produces exactly one Automerge change event (historically a gap
+// when the handler used two separate change() calls).
 // ─────────────────────────────────────────────────────────────────
 
 describe('GAP: task update and history recording are atomic', () => {
@@ -267,11 +260,7 @@ describe('GAP: task update and history recording are atomic', () => {
         priority: 'p2',
       })
 
-      // Patch the task — this should record the update AND its history
-      // in a single docHandle.change() call. Currently the server does:
-      //   1. docHandle.change() to apply the update + push to activity
-      //   2. store.recordTaskChange() which does another docHandle.change()
-      // This means history is written in a separate transaction.
+      // Mutating PATCH should perform one docHandle.change() via updateTask.
       let changeCount = 0
       const onChange = () => {
         changeCount += 1
@@ -289,8 +278,6 @@ describe('GAP: task update and history recording are atomic', () => {
 
       const doc = await getDoc(server)
 
-      // One request should result in one Automerge document change.
-      // Today the HTTP handler still performs two separate writes.
       const activityEntry = doc.activity.find(
         a => a.type === 'task_updated' && a.taskId === taskId
       )
@@ -305,7 +292,7 @@ describe('GAP: task update and history recording are atomic', () => {
       assert.equal(
         changeCount,
         1,
-        'A single HTTP PATCH should produce exactly one Automerge document change — FAILS because the route still updates the task and taskHistory in separate docHandle.change() calls'
+        'A single HTTP PATCH that mutates the task should produce exactly one Automerge document change'
       )
     })
   })


### PR DESCRIPTION
## Summary

- **Single Automerge change per mutating PATCH:** `PATCH /automerge/task/:taskId` delegates to `AutomergeStore.updateTask()`, which applies task fields, `taskHistory`, and `task_updated` activity in one `docHandle.change()` (removes separate `recordTaskChange()` call from this path).
- **PATCH hardening:** Any `!result.success` returns **404** (task not found) or **500** (other); **no-op** updates skip `broadcastDocumentUpdate()` while still returning 200 with `changes: []`.
- **Store:** `if (!doc.activity) doc.activity = []` before activity push in `updateTask`.
- **Tests:** `test/fitness-gaps.test.js` comments updated to match delegation + regression-guard narrative.

## PATCH body → `updates`

Each of `status`, `assignee`, `title`, `description`, `priority` is applied when present in JSON with `!== undefined`; `assignee` is normalized with `assignee || null`.

## Verification

- `npm test`
- `npm run test:gaps` — atomicity suite passes (other GAP tests unchanged).

Closes / supersedes prior inline-only approach (e.g. PR #32) if you retire that branch.

Made with [Cursor](https://cursor.com)