### PR TITLE
Fix Mission Control reconnect loading and error states

### DIFF
--- a/ui-prototype/src/MissionControlSync.jsx
+++ b/ui-prototype/src/MissionControlSync.jsx
@@ -66,6 +66,9 @@ export default function MissionControlSync() {
   const [mobileActiveColumn, setMobileActiveColumn] = useState('in-progress')
   const [view, setView] = useState('board') // 'board' or 'activity'
   const wsRef = useRef(null)
+  // The reconnect timer reuses this callback, so gate the full-page spinner
+  // on whether we have ever received a document, not on stale render state.
+  const hasReceivedDocRef = useRef(false)
 
   const tasksByColumn = useMemo(() => {
     const all = Object.values(doc?.tasks || {})
@@ -77,7 +80,8 @@ export default function MissionControlSync() {
   }, [doc])
 
   const connectToSyncServer = useCallback(async () => {
-    setLoading(true)
+    setError(null)
+    if (!hasReceivedDocRef.current) setLoading(true)
     if (wsRef.current) wsRef.current.close()
     try {
       const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
@@ -89,8 +93,16 @@ export default function MissionControlSync() {
         setError(null)
       }
       ws.onmessage = (event) => {
-        const message = JSON.parse(event.data)
+        let message
+        try {
+          message = JSON.parse(event.data)
+        } catch {
+          setError('Invalid sync message from server')
+          if (!hasReceivedDocRef.current) setLoading(false)
+          return
+        }
         if (message.type === 'document-state' || message.type === 'document-update') {
+          hasReceivedDocRef.current = true
           setDoc(message.doc)
           setLoading(false)
           setSelectedTask((prev) => {
@@ -104,7 +116,10 @@ export default function MissionControlSync() {
         setConnected(false)
         setTimeout(connectToSyncServer, 3000)
       }
-      ws.onerror = () => setError('Connection failed')
+      ws.onerror = () => {
+        setError('Connection failed')
+        if (!hasReceivedDocRef.current) setLoading(false)
+      }
     } catch (err) {
       setError(err.message)
       setLoading(false)
@@ -160,7 +175,17 @@ export default function MissionControlSync() {
   }
   
   if (loading) return <div style={styles.centered}><div style={styles.spinner} /><p style={styles.loadingText}>Connecting...</p></div>
-  if (!doc) return <div style={styles.centered}><p style={styles.loadingText}>Loading...</p></div>
+  if (!doc) {
+    if (error) {
+      return (
+        <div style={styles.centered}>
+          <p style={{ ...styles.loadingText, color: '#fecaca', marginBottom: 16 }}>{error}</p>
+          <button type="button" style={styles.btnPrimary} onClick={() => connectToSyncServer()}>Retry</button>
+        </div>
+      )
+    }
+    return <div style={styles.centered}><p style={styles.loadingText}>Loading...</p></div>
+  }
   
   const tasks = Object.values(doc.tasks || {})
   const agents = Object.values(doc.agents || {})


### PR DESCRIPTION
## Summary
- keep the existing board visible during reconnect attempts after the first document has loaded
- clear stale connection errors before retrying and surface invalid WebSocket payloads safely
- show an explicit error state with a Retry button when the initial document load cannot complete

## Testing
- `npm test`
- `npm run ui:build`